### PR TITLE
Fix Carthage 0.12.0 build error: "Build fails: Failed to read file or folder"

### DIFF
--- a/LNPopupController/Info.plist
+++ b/LNPopupController/Info.plist
@@ -13,6 +13,6 @@
 	<key>LSRequiresIPhoneOS</key>
     <true/>
     <key>CFBundlePackageType</key>
-    <string>BNDL</string>
+    <string>FMWK</string>
 </dict>
 </plist>

--- a/LNPopupController/Info.plist
+++ b/LNPopupController/Info.plist
@@ -7,10 +7,12 @@
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
-	<true/>
+    <true/>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
 </dict>
 </plist>


### PR DESCRIPTION
Carthage build fails with Carthage version 0.12.0. Carthage requires `Info.plist` to contain `CFBundlePackageType` key: https://github.com/Carthage/Carthage/issues/1096#issuecomment-180009895

I also set the version string to correct `1.3`. You might need to bump the version if you push this as a new release.