### PR TITLE
Prevent view from sliding up when panning down

### DIFF
--- a/LNPopupController/LNPopupController/Private/LNPopupController.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupController.m
@@ -447,9 +447,10 @@ static CGFloat __smoothstep(CGFloat a, CGFloat b, CGFloat x)
 			BOOL panThreshold = CACurrentMediaTime() - _lastSeenMovement <= LNPopupBarGesturePanThreshold;
 			BOOL heightTreshold = [self _percentFromPopupBar] > LNPopupBarGestureHeightPercentThreshold;
 			BOOL isPanUp = [pgr velocityInView:_containerController.view].y < 0;
-			BOOL hasPassedOffset = [pgr translationInView:_popupBar.superview].y <= LNPopupBarGestureSnapOffset;
+			BOOL isPanDown = [pgr velocityInView:_containerController.view].y > 0;
+			BOOL hasPassedOffset = abs([pgr translationInView:_popupBar.superview].y) <= LNPopupBarGestureSnapOffset;
 			
-			if((panThreshold || heightTreshold) && (isPanUp || hasPassedOffset))
+			if((panThreshold || heightTreshold) && (isPanUp || hasPassedOffset) && !isPanDown)
 			{
 				[self _transitionToState:LNPopupPresentationStateOpen animated:YES completion:nil userOriginatedTransition:NO];
 			}

--- a/LNPopupController/LNPopupController/Private/LNPopupController.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupController.m
@@ -448,7 +448,7 @@ static CGFloat __smoothstep(CGFloat a, CGFloat b, CGFloat x)
 			BOOL heightTreshold = [self _percentFromPopupBar] > LNPopupBarGestureHeightPercentThreshold;
 			BOOL isPanUp = [pgr velocityInView:_containerController.view].y < 0;
 			BOOL isPanDown = [pgr velocityInView:_containerController.view].y > 0;
-			BOOL hasPassedOffset = abs([pgr translationInView:_popupBar.superview].y) <= LNPopupBarGestureSnapOffset;
+			BOOL hasPassedOffset = [pgr translationInView:_popupBar.superview].y <= LNPopupBarGestureSnapOffset;
 			
 			if((panThreshold || heightTreshold) && (isPanUp || hasPassedOffset) && !isPanDown)
 			{


### PR DESCRIPTION
This makes the swipe gesture slightly better (in my opinion) by preventing the popup from opening when the user is explicitly swiping down at the end of the gesture.

With the current implementation, if you pull the window past the height barrier it opens even when you're actively swiping down at the time you let go. 