### PR TITLE
Fixes slight rounding issue on interactive gesture

### DIFF
--- a/LNPopupController/LNPopupController/Private/LNPopupController.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupController.m
@@ -207,7 +207,12 @@ static const CGFloat        LNPopupBarGestureSnapOffset = 40;
 	CGRect contentFrame = _containerController.view.bounds;
 	contentFrame.origin.x = _popupBar.frame.origin.x;
 	contentFrame.origin.y = _popupBar.frame.origin.y + _popupBar.frame.size.height;
-	contentFrame.size.height = relativeViewForContentView.frame.origin.y - (_popupBar.frame.origin.y + _popupBar.frame.size.height);
+
+	// This rounds the height to the nearest fractional pixel size supported by the main screen of the
+	// current device. It fixes an issue where the view doesn't quite touch all the way to the bottom bar
+	CGFloat screenScale = _containerController.view.window.screen.scale;
+	CGFloat fractionalHeight = relativeViewForContentView.frame.origin.y - (_popupBar.frame.origin.y + _popupBar.frame.size.height);
+	contentFrame.size.height = ceil(fractionalHeight * screenScale) / screenScale;
 	
 	self.popupContentView.frame = contentFrame;
 	_containerController.popupContentViewController.view.frame = _containerController.view.bounds;


### PR DESCRIPTION
When using the interactive gesture (sliding up), the height calculation isn't rounded to the nearest supported pixel for the current screen. This can lead to pixels such as 100.111, which will be rounded down to 100 and show the effect seen in the screenshot below, where the background view can be seen through a thin line between the two views: 

![image](https://cloud.githubusercontent.com/assets/1615780/15778527/c779d654-2964-11e6-8c57-6bb03b3e46fa.png)

This changes simply rounds up to the nearest fractional pixel supported by the current device's scaling factor (so, generally either the nearest half-point or third-point). Fixes the problem in my testing and as far as I can tell doesn't introduce any other issues.