### PR TITLE
Fix detection of compact style.

### DIFF
--- a/LNPopupController/LNPopupController/Private/LNPopupBar.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupBar.m
@@ -504,7 +504,7 @@ UIBlurEffectStyle _LNBlurEffectStyleForSystemBarStyle(UIBarStyle systemBarStyle,
 			}
 			
 			NSMutableParagraphStyle* paragraph = [NSMutableParagraphStyle new];
-			if(_resolvedStyle == LNPopupBarHeightCompact)
+			if(_resolvedStyle == LNPopupBarStyleCompact)
 			{
 				paragraph.alignment = NSTextAlignmentCenter;
 			}


### PR DESCRIPTION
I noticed while using iOS 10 but displaying the iOS 9-like compact bar, the title was not centered. After searching through the code I found this comparison which is probably wrong, comparing to the correct value correctly uses centered text alignment for the titles.

Before:

![left](https://cloud.githubusercontent.com/assets/9538837/23507078/a3388af2-ff4b-11e6-819f-1a957b076926.png)

After (fixed):

![centered](https://cloud.githubusercontent.com/assets/9538837/23507129/d9a10196-ff4b-11e6-8ebe-6aa9d82c1592.png)
