### PR TITLE
implemented gestureRecognizer:shouldReceiveTouch: to prevent conflicts with UIControls

### DIFF
--- a/LNPopupController/LNPopupController/Private/LNPopupController.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupController.m
@@ -1272,6 +1272,16 @@ static CGFloat __smoothstep(CGFloat a, CGFloat b, CGFloat x)
 	return YES;
 }
 
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
+{
+    if([touch.view isKindOfClass:[UIControl class]])
+    {
+        return NO;
+    }
+
+    return YES;
+}
+
 #pragma mark UIViewControllerPreviewingDelegate
 
 - (nullable UIViewController *)previewingContext:(id <UIViewControllerPreviewing>)previewingContext viewControllerForLocation:(CGPoint)location


### PR DESCRIPTION
I have a UIControl in my contentViewController that uses touch tracking (a custom scrubber bar). In order to prevent touch conflicts between LNPopupControl's PanGestureRecognizer and the UIControl I implemented the `gestureRecognizer:shouldReceiveTouch:` delegate method.