### PR TITLE
Add option to keep close arrow on top of navigation bar

### DIFF
--- a/LNPopupController/LNPopupController/LNPopupContentView.h
+++ b/LNPopupController/LNPopupController/LNPopupContentView.h
@@ -34,6 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, readonly) LNPopupCloseButton* popupCloseButton;
 
+/**
+ * Move close button under navigation bars
+ */
+@property (nonatomic) BOOL popupCloseButtonMoveForNavigationBars;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/LNPopupController/LNPopupController/LNPopupContentView.h
+++ b/LNPopupController/LNPopupController/LNPopupContentView.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Move close button under navigation bars
  */
-@property (nonatomic) BOOL popupCloseButtonMoveForNavigationBars;
+@property (nonatomic) BOOL popupCloseButtonAutomaticallyUnobstructsTopBars;
 
 @end
 

--- a/LNPopupController/LNPopupController/Private/LNPopupController.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupController.m
@@ -996,13 +996,15 @@ static CGFloat __smoothstep(CGFloat a, CGFloat b, CGFloat x)
 		_popupCloseButtonTopConstraint.constant += (_containerController.popupContentViewController.prefersStatusBarHidden ? 0 : [UIApplication sharedApplication].statusBarFrame.size.height);
 	}
 	
-    if (_popupContentView.popupCloseButtonMoveForNavigationBars){
-        id hitTest = [[_currentContentController view] hitTest:CGPointMake(12, _popupCloseButtonTopConstraint.constant) withEvent:nil];
-        UINavigationBar* possibleBar = (id)[self _view:hitTest selfOrSuperviewKindOfClass:[UINavigationBar class]];
-        if(possibleBar)
-        {
+    
+    id hitTest = [[_currentContentController view] hitTest:CGPointMake(12, _popupCloseButtonTopConstraint.constant) withEvent:nil];
+    UINavigationBar* possibleBar = (id)[self _view:hitTest selfOrSuperviewKindOfClass:[UINavigationBar class]];
+    if(possibleBar)
+    {
+        if (_popupContentView.popupCloseButtonMoveForNavigationBars)
             _popupCloseButtonTopConstraint.constant += CGRectGetHeight(possibleBar.bounds);
-        }
+        else
+            _popupCloseButtonTopConstraint.constant += 6;
     }
 	
 	if(startingTopConstant != _popupCloseButtonTopConstraint.constant)

--- a/LNPopupController/LNPopupController/Private/LNPopupController.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupController.m
@@ -163,7 +163,7 @@ static const CGFloat LNPopupBarDeveloperPanGestureThreshold = 0;
 		_effectView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 		[self addSubview:_effectView];
         
-        _popupCloseButtonMoveForNavigationBars = YES;
+        _popupCloseButtonAutomaticallyUnobstructsTopBars = YES;
 	}
 	
 	return self;
@@ -1001,7 +1001,7 @@ static CGFloat __smoothstep(CGFloat a, CGFloat b, CGFloat x)
     UINavigationBar* possibleBar = (id)[self _view:hitTest selfOrSuperviewKindOfClass:[UINavigationBar class]];
     if(possibleBar)
     {
-        if (_popupContentView.popupCloseButtonMoveForNavigationBars)
+        if (_popupContentView.popupCloseButtonAutomaticallyUnobstructsTopBars)
             _popupCloseButtonTopConstraint.constant += CGRectGetHeight(possibleBar.bounds);
         else
             _popupCloseButtonTopConstraint.constant += 6;

--- a/LNPopupController/LNPopupController/Private/LNPopupController.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupController.m
@@ -162,6 +162,8 @@ static const CGFloat LNPopupBarDeveloperPanGestureThreshold = 0;
 		_effectView.frame = self.bounds;
 		_effectView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 		[self addSubview:_effectView];
+        
+        _popupCloseButtonMoveForNavigationBars = YES;
 	}
 	
 	return self;
@@ -994,12 +996,14 @@ static CGFloat __smoothstep(CGFloat a, CGFloat b, CGFloat x)
 		_popupCloseButtonTopConstraint.constant += (_containerController.popupContentViewController.prefersStatusBarHidden ? 0 : [UIApplication sharedApplication].statusBarFrame.size.height);
 	}
 	
-	id hitTest = [[_currentContentController view] hitTest:CGPointMake(12, _popupCloseButtonTopConstraint.constant) withEvent:nil];
-	UINavigationBar* possibleBar = (id)[self _view:hitTest selfOrSuperviewKindOfClass:[UINavigationBar class]];
-	if(possibleBar)
-	{
-		_popupCloseButtonTopConstraint.constant += CGRectGetHeight(possibleBar.bounds);
-	}
+    if (_popupContentView.popupCloseButtonMoveForNavigationBars){
+        id hitTest = [[_currentContentController view] hitTest:CGPointMake(12, _popupCloseButtonTopConstraint.constant) withEvent:nil];
+        UINavigationBar* possibleBar = (id)[self _view:hitTest selfOrSuperviewKindOfClass:[UINavigationBar class]];
+        if(possibleBar)
+        {
+            _popupCloseButtonTopConstraint.constant += CGRectGetHeight(possibleBar.bounds);
+        }
+    }
 	
 	if(startingTopConstant != _popupCloseButtonTopConstraint.constant)
 	{


### PR DESCRIPTION
Allow the close arrow to be on top of the nav bar. This can achieve something like the attached screenshot:

![simulator screen shot - iphone 6s - 2018-08-22 at 15 47 38](https://user-images.githubusercontent.com/1431548/44495061-39e25300-a623-11e8-8a3a-2396e3b7b969.png)
