### PR TITLE
Support iPad (popupBar being inline with UITabBarController's tab bar)

### DIFF
--- a/LNPopupController/LNPopupController/LNPopupBar.h
+++ b/LNPopupController/LNPopupController/LNPopupBar.h
@@ -119,6 +119,11 @@ typedef NS_ENUM(NSUInteger, LNPopupBarProgressViewStyle) {
 @property (nonatomic, assign) LNPopupBarStyle barStyle UI_APPEARANCE_SELECTOR;
 
 /**
+ * Popup Bar is inline in tab bar
+ */
+@property (nonatomic, assign) BOOL isInlineWithTabBar;
+
+/**
  * The popup bar's progress style.
  */
 @property (nonatomic, assign) LNPopupBarProgressViewStyle progressViewStyle;

--- a/LNPopupController/LNPopupController/LNPopupBar.h
+++ b/LNPopupController/LNPopupController/LNPopupBar.h
@@ -119,7 +119,7 @@ typedef NS_ENUM(NSUInteger, LNPopupBarProgressViewStyle) {
 @property (nonatomic, assign) LNPopupBarStyle barStyle UI_APPEARANCE_SELECTOR;
 
 /**
- * Popup Bar is inline in tab bar
+ * The popup bar is displayed inline in tab bars.
  */
 @property (nonatomic, assign) BOOL isInlineWithTabBar;
 

--- a/LNPopupController/LNPopupController/Private/LNPopupBar+Private.h
+++ b/LNPopupController/LNPopupController/Private/LNPopupBar+Private.h
@@ -10,10 +10,14 @@
 
 extern const CGFloat LNPopupBarHeightCompact;
 extern const CGFloat LNPopupBarHeightProminent;
+extern const CGFloat LNPopupBarHeightTabBarInline;
 
-inline __attribute__((always_inline)) CGFloat _LNPopupBarHeightForBarStyle(LNPopupBarStyle style, LNPopupCustomBarViewController* customBarVC)
+inline __attribute__((always_inline)) CGFloat _LNPopupBarHeightForBarStyle(LNPopupBarStyle style, BOOL inlineWithTabBar, LNPopupCustomBarViewController* customBarVC)
 {
 	if(customBarVC) { return customBarVC.preferredContentSize.height; }
+    
+	if (inlineWithTabBar)
+		return LNPopupBarHeightTabBarInline;
 	
 	return style == LNPopupBarStyleCompact ? LNPopupBarHeightCompact : LNPopupBarHeightProminent;
 }

--- a/LNPopupController/LNPopupController/Private/LNPopupBar+Private.h
+++ b/LNPopupController/LNPopupController/Private/LNPopupBar+Private.h
@@ -17,7 +17,9 @@ inline __attribute__((always_inline)) CGFloat _LNPopupBarHeightForBarStyle(LNPop
 	if(customBarVC) { return customBarVC.preferredContentSize.height; }
     
 	if (inlineWithTabBar)
+	{
 		return LNPopupBarHeightTabBarInline;
+	}
 	
 	return style == LNPopupBarStyleCompact ? LNPopupBarHeightCompact : LNPopupBarHeightProminent;
 }

--- a/LNPopupController/LNPopupController/Private/LNPopupBar.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupBar.m
@@ -96,6 +96,7 @@
 
 const CGFloat LNPopupBarHeightCompact = 40.0;
 const CGFloat LNPopupBarHeightProminent = 64.0;
+const CGFloat LNPopupBarHeightTabBarInline = 50.0;
 const CGFloat LNPopupBarProminentImageWidth = 48.0;
 
 const NSInteger LNBackgroundStyleInherit = -1;
@@ -118,6 +119,7 @@ const NSInteger LNBackgroundStyleInherit = -1;
 	UIBlurEffect* _customBlurEffect;
 	
 	UIView* _shadowView;
+	UIView* _separatorView;
     
     NSArray<__kindof NSLayoutConstraint *> * _progressViewVerticalConstraints;
 }
@@ -246,8 +248,12 @@ static inline __attribute__((always_inline)) UIBlurEffectStyle _LNBlurEffectStyl
 		
 		_shadowView = [UIView new];
 		_shadowView.backgroundColor = [[UIColor blackColor] colorWithAlphaComponent:0.3];
-		[_backgroundView.contentView addSubview:_shadowView];
+		[self addSubview:_shadowView];
 		
+		_separatorView = [UIView new];
+		_separatorView.backgroundColor = [UIColor colorWithWhite:169.0 / 255.0 alpha:1.0];
+		[self addSubview:_separatorView];
+        
 		_highlightView = [[UIView alloc] initWithFrame:self.bounds];
 		_highlightView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 		_highlightView.userInteractionEnabled = NO;
@@ -294,7 +300,7 @@ static inline __attribute__((always_inline)) UIBlurEffectStyle _LNBlurEffectStyl
 	[self _layoutImageView];
 	
 	[UIView performWithoutAnimation:^{
-		_toolbar.frame = CGRectMake(0, 0, self.bounds.size.width, _LNPopupBarHeightForBarStyle(_resolvedStyle, _customBarViewController));
+		_toolbar.frame = CGRectMake(0, 0, self.bounds.size.width, _LNPopupBarHeightForBarStyle(_resolvedStyle, self.isInlineWithTabBar, _customBarViewController));
 		[_toolbar layoutIfNeeded];
 		
 		[self bringSubviewToFront:_highlightView];
@@ -302,8 +308,14 @@ static inline __attribute__((always_inline)) UIBlurEffectStyle _LNBlurEffectStyl
 		//	[_toolbar bringSubviewToFront:_imageView];
 		//	[_toolbar bringSubviewToFront:_titlesView];
 		[self bringSubviewToFront:_shadowView];
+		[self bringSubviewToFront:_separatorView];
 		
-		_shadowView.frame = CGRectMake(0, 0, self.toolbar.bounds.size.width, 1 / self.window.screen.scale);
+		_shadowView.frame = CGRectMake(0, self.isInlineWithTabBar ? 0.5 : 0, self.toolbar.bounds.size.width, 1 / self.window.screen.scale);
+		if (self.isInlineWithTabBar){
+			_separatorView.frame = CGRectMake(0.5, 0, 1 / self.window.screen.nativeScale, self.toolbar.bounds.size.height);
+		} else {
+			_separatorView.frame = CGRectZero;
+		}
 		
 		[self _layoutTitles];
 	}];
@@ -455,6 +467,7 @@ static inline __attribute__((always_inline)) UIBlurEffectStyle _LNBlurEffectStyl
 	_systemShadowColor = systemShadowColor;
 	
 	_shadowView.backgroundColor = systemShadowColor;
+	_separatorView.backgroundColor = systemShadowColor;
 }
 
 - (void)setTranslucent:(BOOL)translucent
@@ -809,7 +822,7 @@ static inline __attribute__((always_inline)) UIBlurEffectStyle _LNBlurEffectStyl
 	
 	CGRect titleLabelFrame = _titlesView.bounds;
 	
-	CGFloat barHeight = _LNPopupBarHeightForBarStyle(_resolvedStyle, _customBarViewController);
+	CGFloat barHeight = _LNPopupBarHeightForBarStyle(_resolvedStyle, self.isInlineWithTabBar, _customBarViewController);
 	titleLabelFrame.size.height = barHeight;
 	if(_subtitle.length > 0)
 	{

--- a/LNPopupController/LNPopupController/Private/LNPopupBar.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupBar.m
@@ -311,9 +311,11 @@ static inline __attribute__((always_inline)) UIBlurEffectStyle _LNBlurEffectStyl
 		[self bringSubviewToFront:_separatorView];
 		
 		_shadowView.frame = CGRectMake(0, self.isInlineWithTabBar ? 0.5 : 0, self.toolbar.bounds.size.width, 1 / self.window.screen.scale);
-		if (self.isInlineWithTabBar){
+		if (self.isInlineWithTabBar)
+		{
 			_separatorView.frame = CGRectMake(0.5, 0, 1 / self.window.screen.nativeScale, self.toolbar.bounds.size.height);
-		} else {
+		} else
+		{
 			_separatorView.frame = CGRectZero;
 		}
 		

--- a/LNPopupController/LNPopupController/Private/LNPopupController.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupController.m
@@ -312,7 +312,10 @@ LNPopupCloseButtonStyle _LNPopupResolveCloseButtonStyleFromCloseButtonStyle(LNPo
 	contentFrame.size.height = ceil(fractionalHeight);
 	
 	self.popupContentView.frame = contentFrame;
-	_containerController.popupContentViewController.view.frame = self.popupContentView.bounds;
+	
+	CGRect frame = self.popupContentView.bounds;
+	frame.size.height = MAX(_containerController.view.bounds.size.height, 0);
+	_containerController.popupContentViewController.view.frame = frame;
 	
 	[self _repositionPopupCloseButton];
 }

--- a/LNPopupController/LNPopupController/Private/LNPopupController.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupController.m
@@ -269,10 +269,12 @@ LNPopupCloseButtonStyle _LNPopupResolveCloseButtonStyleFromCloseButtonStyle(LNPo
 - (CGRect)_frameForOpenPopupBar
 {
 //	CGRect defaultFrame = [_containerController defaultFrameForBottomDockingView_internalOrDeveloper];
-	if (self.popupBar.isInlineWithTabBar){
+	if (self.popupBar.isInlineWithTabBar)
+	{
 		UIEdgeInsets insets = [_containerController insetsForBottomDockingView];
 		return CGRectMake(insets.left, - self.popupBar.frame.size.height, _containerController.view.bounds.size.width - (insets.left + insets.right), self.popupBar.frame.size.height);
 	}
+	
 	return CGRectMake(0, - self.popupBar.frame.size.height, _containerController.view.bounds.size.width, self.popupBar.frame.size.height);
 }
 
@@ -293,7 +295,8 @@ LNPopupCloseButtonStyle _LNPopupResolveCloseButtonStyleFromCloseButtonStyle(LNPo
 	if(bottomBar)
 	{
 		CGRect bottomBarFrame = _cachedDefaultFrame;
-		if (!self.popupBar.isInlineWithTabBar){
+		if (!self.popupBar.isInlineWithTabBar)
+		{
 			bottomBarFrame.origin.y -= _cachedInsets.bottom;
 			bottomBarFrame.origin.y += (percent * (bottomBarFrame.size.height + _cachedInsets.bottom));
 		}
@@ -932,8 +935,11 @@ static CGFloat __smoothstep(CGFloat a, CGFloat b, CGFloat x)
 		if([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 10)
 		{
 			UIColor *color = [_bottomBar valueForKeyPath:str2];
-			if (!color)
+			if (color == nil)
+			{
 				color = [UIColor colorWithWhite:0 alpha:0.29];
+			}
+			
 			self.popupBar.systemShadowColor = color;
 		}
 		else


### PR DESCRIPTION
This adds support for Music-App Style popup controller on iPad.

Screenshots attached.

(My fork also has some stuff for dimming the background, but for sake of organization, I intend on putting that in a separate pull request)

![simulator screen shot - ipad pro 10 5-inch - 2019-02-22 at 22 30 14](https://user-images.githubusercontent.com/1431548/53282868-d67ccf00-36f2-11e9-82f9-58696fb854f2.png)
![simulator screen shot - ipad pro 10 5-inch - 2019-02-22 at 22 30 12](https://user-images.githubusercontent.com/1431548/53282870-d977bf80-36f2-11e9-9b38-8693d3aa780c.png)
