### PR TITLE
Fix Xcode 11 crash with UIImage

### DIFF
--- a/LNPopupController/LNPopupController/Private/LNPopupBar.m
+++ b/LNPopupController/LNPopupController/Private/LNPopupBar.m
@@ -205,7 +205,7 @@ static UIBlurEffectStyle _LNBlurEffectStyleForSystemBarStyle(UIBarStyle systemBa
 		
 		_progressView = [[UIProgressView alloc] initWithProgressViewStyle:UIProgressViewStyleDefault];
 		_progressView.translatesAutoresizingMaskIntoConstraints = NO;
-		_progressView.trackImage = [UIImage alloc];
+		_progressView.trackImage = [[UIImage alloc] init];
 		[_toolbar addSubview:_progressView];
 		[self _updateProgressViewWithStyle:self.progressViewStyle];
         


### PR DESCRIPTION
Fix for:
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'This UIImage instance unexpectedly has nil content. Did calling code create an image with [UIImage alloc] without also sending -init? That's unsupported. 0x6000035b2fd0'
*** First throw call stack:
(
    0   CoreFoundation                      0x00007fff23b98bde __exceptionPreprocess + 350
    1   libobjc.A.dylib                     0x00007fff503b5b20 objc_exception_throw + 48
    2   CoreFoundation                      0x00007fff23b98a1c +[NSException raise:format:] + 188
    3   UIKitCore                           0x00007fff46d8655e -[UIImage size] + 95
    4   UIKitCore                           0x00007fff4689b6de -[UIToolbar setBackgroundImage:forToolbarPosition:barMetrics:] + 215
    5   LNPopupController                   0x0000000105b72660 -[LNPopupBar initWithFrame:] + 1008
    6   LNPopupController                   0x0000000105b882d2 -[LNPopupController popupBarStorage] + 210
    7   LNPopupController                   0x0000000105b9fec5 -[UIViewController(LNPopupSupport) popupBar] + 85