### PR TITLE
Added podspec and possibility to register buggy additional safe area classes

### DIFF
--- a/LNPopupController.podspec
+++ b/LNPopupController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LNPopupController'
-  s.version          = '2.0.0'  # ← set to a real tag from the repo
+  s.version          = '4.0.5'
   s.summary          = 'A framework for presenting popup bars and content views.'
   s.description      = 'LNPopupController provides a popup bar, similar to Apple Music and Podcasts.'
   s.homepage         = 'https://github.com/LeoNatan/LNPopupController'

--- a/LNPopupController.podspec
+++ b/LNPopupController.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/LeoNatan/LNPopupController'
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { 'Leo Natan' => 'leonatan@icloud.com' }
-  s.source       = { :git => 'https://github.com/LeoNatan/LNPopupController.git', :tag => s.version.to_s }
+  s.source       = { :git => 'https://github.com/everappz/LNPopupController.git', :tag => s.version.to_s }
 
   s.swift_version = '5.9'
   s.platforms = { :ios => '13.0' }

--- a/LNPopupController.podspec
+++ b/LNPopupController.podspec
@@ -1,43 +1,42 @@
 Pod::Spec.new do |s|
-  s.name             = 'LNPopupController'
-  s.version          = '4.0.5'
-  s.summary          = 'A framework for presenting popup bars and content views.'
-  s.description      = 'LNPopupController provides a popup bar, similar to Apple Music and Podcasts.'
-  s.homepage         = 'https://github.com/LeoNatan/LNPopupController'
-  s.license          = { :type => 'MIT', :file => 'LICENSE' }
-  s.author           = { 'Leo Natan' => 'leonatan@icloud.com' }
+  s.name         = 'LNPopupController'
+  s.version      = '4.0.5'  # use a real tag from the repo
+  s.summary      = 'Popup bar like Apple Music/Podcasts.'
+  s.description  = 'LNPopupController provides a popup bar and content presentation.'
+  s.homepage     = 'https://github.com/LeoNatan/LNPopupController'
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.author       = { 'Leo Natan' => 'leonatan@icloud.com' }
+  s.source       = { :git => 'https://github.com/LeoNatan/LNPopupController.git', :tag => s.version.to_s }
 
-  s.source           = { :git => 'https://github.com/LeoNatan/LNPopupController.git', :tag => s.version.to_s }
+  s.swift_version = '5.9'
+  s.platforms = { :ios => '13.0' }
 
-  s.swift_version    = '5.9'
-  s.platforms        = { :ios => '13.0' }  # Mac Catalyst enabled via xcconfig below
+  # Subspec mirroring SPM targets
+  s.subspec 'ObjC' do |ss|
+    ss.source_files = [
+      'LNPopupController/LNPopupController/**/*.{h,m,mm,c,cpp}',   # ObjC sources (and their headers)
+      'LNPopupController/LNPopupController.h'                      # umbrella header (top-level)
+    ]
+    ss.public_header_files = [
+      'LNPopupController/LNPopupController/**/*.h',
+      'LNPopupController/LNPopupController.h'
+    ]
+    ss.exclude_files = ['LNPopupController/Info.plist']
 
-  s.requires_arc     = true
-  s.module_name      = 'LNPopupController'
+    ss.frameworks = 'UIKit'
+    ss.pod_target_xcconfig = {
+      'HEADER_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/LNPopupController/LNPopupController $(PODS_TARGET_SRCROOT)/LNPopupController/LNPopupController/Private',
+      'SUPPORTS_MACCATALYST' => 'YES',
+      'DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER' => 'YES',
+      'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++20'
+    }
+  end
 
-  # ObjC core
-  s.public_header_files = 'LNPopupController/include/**/*.h'
-  s.source_files        = [
-    'LNPopupController/**/*.{h,m,mm,c,cpp}',
-    'LNPCSwiftRefinements/**/*.{swift}'
-  ]
-  s.exclude_files = [
-    'LNPopupController/Info.plist'
-  ]
+  s.subspec 'Swift' do |ss|
+    ss.dependency 'LNPopupController/ObjC'
+    ss.source_files = 'LNPCSwiftRefinements/**/*.swift'            # Swift target only
+  end
 
-  s.frameworks = 'UIKit'
-  s.ios.deployment_target = '13.0'
-
-  # Header search paths required by SPM target config (include + Private)
-  s.pod_target_xcconfig = {
-    'HEADER_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/LNPopupController $(PODS_TARGET_SRCROOT)/LNPopupController/Private',
-    # Mac Catalyst support
-    'SUPPORTS_MACCATALYST' => 'YES',
-    'DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER' => 'YES',
-    # Match SPM’s C++ standard just in case
-    'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++20'
-  }
-
-  # If the project uses resource images in the future, declare them here:
-  # s.resource_bundles = { 'LNPopupController' => ['LNPopupController/Resources/**/*'] }
+  # Default = both targets
+  s.default_subspecs = ['ObjC', 'Swift']
 end

--- a/LNPopupController.podspec
+++ b/LNPopupController.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   # Subspec mirroring SPM targets
   s.subspec 'ObjC' do |ss|
     ss.source_files = [
-      'LNPopupController/LNPopupController/**/*.{h,m,mm,c,cpp}',   # ObjC sources (and their headers)
+      'LNPopupController/LNPopupController/**/*.{h,m,mm,c,cpp,hh}',   # ObjC sources (and their headers)
       'LNPopupController/LNPopupController.h'                      # umbrella header (top-level)
     ]
     ss.public_header_files = [

--- a/LNPopupController.podspec
+++ b/LNPopupController.podspec
@@ -1,0 +1,43 @@
+Pod::Spec.new do |s|
+  s.name             = 'LNPopupController'
+  s.version          = '2.0.0'  # ← set to a real tag from the repo
+  s.summary          = 'A framework for presenting popup bars and content views.'
+  s.description      = 'LNPopupController provides a popup bar, similar to Apple Music and Podcasts.'
+  s.homepage         = 'https://github.com/LeoNatan/LNPopupController'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'Leo Natan' => 'leonatan@icloud.com' }
+
+  s.source           = { :git => 'https://github.com/LeoNatan/LNPopupController.git', :tag => s.version.to_s }
+
+  s.swift_version    = '5.9'
+  s.platforms        = { :ios => '13.0' }  # Mac Catalyst enabled via xcconfig below
+
+  s.requires_arc     = true
+  s.module_name      = 'LNPopupController'
+
+  # ObjC core
+  s.public_header_files = 'LNPopupController/include/**/*.h'
+  s.source_files        = [
+    'LNPopupController/**/*.{h,m,mm,c,cpp}',
+    'LNPCSwiftRefinements/**/*.{swift}'
+  ]
+  s.exclude_files = [
+    'LNPopupController/Info.plist'
+  ]
+
+  s.frameworks = 'UIKit'
+  s.ios.deployment_target = '13.0'
+
+  # Header search paths required by SPM target config (include + Private)
+  s.pod_target_xcconfig = {
+    'HEADER_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/LNPopupController $(PODS_TARGET_SRCROOT)/LNPopupController/Private',
+    # Mac Catalyst support
+    'SUPPORTS_MACCATALYST' => 'YES',
+    'DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER' => 'YES',
+    # Match SPM’s C++ standard just in case
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++20'
+  }
+
+  # If the project uses resource images in the future, declare them here:
+  # s.resource_bundles = { 'LNPopupController' => ['LNPopupController/Resources/**/*'] }
+end

--- a/LNPopupController.podspec
+++ b/LNPopupController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'LNPopupController'
-  s.version      = '4.0.5'  # use a real tag from the repo
+  s.version      = '4.0.5'
   s.summary      = 'Popup bar like Apple Music/Podcasts.'
   s.description  = 'LNPopupController provides a popup bar and content presentation.'
   s.homepage     = 'https://github.com/LeoNatan/LNPopupController'
@@ -11,16 +11,20 @@ Pod::Spec.new do |s|
   s.swift_version = '5.9'
   s.platforms = { :ios => '13.0' }
 
-  # Subspec mirroring SPM targets
   s.subspec 'ObjC' do |ss|
     ss.source_files = [
-      'LNPopupController/LNPopupController/**/*.{h,m,mm,c,cpp,hh}',   # ObjC sources (and their headers)
-      'LNPopupController/LNPopupController.h'                      # umbrella header (top-level)
-    ]
-    ss.public_header_files = [
-      'LNPopupController/LNPopupController/**/*.h',
+      'LNPopupController/LNPopupController/**/*.{m,mm,c,cpp}',
+      'LNPopupController/LNPopupController/*.h',
       'LNPopupController/LNPopupController.h'
     ]
+
+    ss.private_header_files = 'LNPopupController/LNPopupController/Private/**/*.{h,hh}'
+
+    ss.public_header_files = [
+      'LNPopupController/LNPopupController/*.h',
+      'LNPopupController/LNPopupController.h'
+    ]
+
     ss.exclude_files = ['LNPopupController/Info.plist']
 
     ss.frameworks = 'UIKit'
@@ -34,9 +38,8 @@ Pod::Spec.new do |s|
 
   s.subspec 'Swift' do |ss|
     ss.dependency 'LNPopupController/ObjC'
-    ss.source_files = 'LNPCSwiftRefinements/**/*.swift'            # Swift target only
+    ss.source_files = 'LNPCSwiftRefinements/**/*.swift'
   end
 
-  # Default = both targets
   s.default_subspecs = ['ObjC', 'Swift']
 end

--- a/LNPopupController.podspec
+++ b/LNPopupController.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'ObjC' do |ss|
     ss.source_files = [
-      'LNPopupController/LNPopupController/**/*.{m,mm,c,cpp}',
+      'LNPopupController/LNPopupController/**/*.{m,mm,c,cpp,h,hh}',
       'LNPopupController/LNPopupController/*.h',
       'LNPopupController/LNPopupController.h'
     ]

--- a/LNPopupController/LNPopupController/Private/UIViewController+LNPopupSupportPrivate.mm
+++ b/LNPopupController/LNPopupController/Private/UIViewController+LNPopupSupportPrivate.mm
@@ -159,6 +159,16 @@ UIRectEdge __ln_hideBarEdge = UIRectEdgeNone;
 
 @implementation UIViewController (LNPopupLayout)
 
+void LNPopupRegisterBuggyAdditionalSafeAreaClasses(NSArray<Class> *classes)
+{
+    if (classes.count == 0) return;
+    @synchronized (__LNPopupBuggyAdditionalSafeAreaClasses) {
+        NSMutableSet *m = (__LNPopupBuggyAdditionalSafeAreaClasses ? [__LNPopupBuggyAdditionalSafeAreaClasses mutableCopy] : [NSMutableSet new]);
+        for (Class c in classes) { if (c) [m addObject:c]; }
+        __LNPopupBuggyAdditionalSafeAreaClasses = [m copy];
+    }
+}
+
 + (void)load
 {
 	@autoreleasepool

--- a/LNPopupController/LNPopupController/UIViewController+LNPopupSupport.h
+++ b/LNPopupController/LNPopupController/UIViewController+LNPopupSupport.h
@@ -302,4 +302,6 @@ NS_SWIFT_UI_ACTOR
 
 @interface LNPopupImageView (TransitionSupport) <LNPopupTransitionView> @end
 
+FOUNDATION_EXPORT void LNPopupRegisterBuggyAdditionalSafeAreaClasses(NSArray<Class> * _Nullable classes);
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Hi,

Thanks for the great library!

I’ve made a couple of fixes that you might find useful:

1. Added a podspec file so developers using CocoaPods can easily integrate the library. (You can edit it and update the source to point to your repo.)
2. Added support for `LNPopupRegisterBuggyAdditionalSafeAreaClasses`. This is helpful when using a custom tabbar controller, since it needs to be registered so the library can automatically apply insets, just like it already does for `UINavigationController` and `UITabBarController`.