### PR TITLE
Allow opting out of iOS 26 legacy-to-floating bar style conversion

### DIFF
--- a/LNPopupController/LNPopupController/LNPopupBar.h
+++ b/LNPopupController/LNPopupController/LNPopupBar.h
@@ -96,6 +96,13 @@ NS_SWIFT_UI_ACTOR
 /// A popup bar is a view that displays popup information. Content is populated from ``LNPopupItem`` items.
 @interface LNPopupBar : UIView <UIAppearanceContainer>
 
+/// Controls whether non-floating bar styles are automatically converted to floating styles on iOS 26 and later.
+///
+/// Defaults to `true`.
+///
+/// Set this to `false` before presenting a popup bar if you want to keep legacy non-floating style resolution behavior.
+@property (class, nonatomic, assign) BOOL convertsLegacyBarStylesToFloatingOnIOS26;
+
 /// If `true`, the popup bar will automatically inherit its appearance from the bottom docking view.
 ///
 /// Defaults to `true`.

--- a/LNPopupController/LNPopupController/Private/Appearance/LNPopupBarAppearance.mm
+++ b/LNPopupController/LNPopupController/Private/Appearance/LNPopupBarAppearance.mm
@@ -248,19 +248,7 @@ static NSArray* __notifiedProperties = nil;
 	
 	if(isCustomBar)
 	{
-		if(wantsFullWidth)
-		{
-			return [UICornerConfiguration configurationWithUniformRadius:[UICornerRadius fixedRadius:20]];
-		}
-		
-		if(barHeight < 70)
-		{
-			return [UICornerConfiguration capsuleConfiguration];
-		}
-		
-		CGFloat margin = MAX(margins.left, margins.right);
-		CGFloat screenRadius = MAX((screen ?: UIScreen.mainScreen)._ln_cornerRadius, margin + 20);
-		return [UICornerConfiguration configurationWithUniformRadius:[UICornerRadius fixedRadius:screenRadius - margin]];
+		return [UICornerConfiguration configurationWithUniformRadius:[UICornerRadius fixedRadius:6]];
 	}
 	
 	return [UICornerConfiguration capsuleConfiguration];

--- a/LNPopupController/LNPopupController/Private/LNPopupBar.mm
+++ b/LNPopupController/LNPopupController/Private/LNPopupBar.mm
@@ -122,7 +122,7 @@ LNPopupBarStyle _LNPopupResolveBarStyleFromBarStyle(LNPopupBarStyle style, BOOL*
 	
 	LNPopupBarStyle rv = style;
 	
-	if(LNPopupEnvironmentHasGlass())
+	if(LNPopupEnvironmentHasGlass() && LNPopupBar.convertsLegacyBarStylesToFloatingOnIOS26)
 	{
 		if(isFloating)
 		{
@@ -233,6 +233,18 @@ __attribute__((objc_direct_members))
 	BOOL _animatesItemSetter;
 	
 	NSArray<UIBarButtonItem*>* _nonSpacingBarButtonItems;
+}
+
+static BOOL __ln_convertsLegacyBarStylesToFloatingOnIOS26 = YES;
+
++ (BOOL)convertsLegacyBarStylesToFloatingOnIOS26
+{
+	return __ln_convertsLegacyBarStylesToFloatingOnIOS26;
+}
+
++ (void)setConvertsLegacyBarStylesToFloatingOnIOS26:(BOOL)convertsLegacyBarStylesToFloatingOnIOS26
+{
+	__ln_convertsLegacyBarStylesToFloatingOnIOS26 = convertsLegacyBarStylesToFloatingOnIOS26;
 }
 
 static BOOL __animatesItemSetter = NO;


### PR DESCRIPTION
- Add public LNPopupBar class property convertsLegacyBarStylesToFloatingOnIOS26
- Keep default behavior unchanged (conversion enabled by default)
- Gate iOS 26 legacy style auto-conversion behind the new runtime switch