### PR TITLE
Fix popup content animating from the container origin on first open

### DIFF
--- a/LNPopupController/LNPopupController/Private/LNPopupController.mm
+++ b/LNPopupController/LNPopupController/Private/LNPopupController.mm
@@ -355,10 +355,19 @@ __attribute__((objc_direct_members))
 		contentFrame.origin.y -= offset;
 	}
 	
-	if([self.popupContentView isDescendantOfView:controllerForContent.view] == NO)
+	//Only convert when the content view is in a hierarchy; converting through a nil superview yields CGRectZero.
+	if(self.popupContentView.superview != nil && [self.popupContentView isDescendantOfView:controllerForContent.view] == NO)
 	{
 		contentFrame = [self.popupContentView.superview convertRect:contentFrame fromView:controllerForContent.view];
 	}
+	
+#if DEBUG
+	if(self.popupContentView.superview == nil && UIView.inheritedAnimationDuration > 0.0)
+	{
+		os_log_t customLog = __LNPopupFrameworkLogger("Layout");
+		os_log_with_type(customLog, OS_LOG_TYPE_DEBUG, "%{public}@: Popup content view frame computed inside an animation before the view was added to a superview; the frame may animate from the wrong origin.", __LNPopupFrameworkName());
+	}
+#endif
 	
 	self.popupContentView.frame = contentFrame;
 	

--- a/LNPopupController/LNPopupController/Private/UIViewController+LNPopupSupportPrivate.mm
+++ b/LNPopupController/LNPopupController/Private/UIViewController+LNPopupSupportPrivate.mm
@@ -863,6 +863,12 @@ UIEdgeInsets _LNPopupChildAdditiveSafeAreas(__kindof UIViewController* self)
 			self._ln_popupController_nocreate.popupBar.backgroundView.alpha = self._ln_popupController_nocreate.popupBar.resolvedIsFloating ? 0.0 : 1.0;
 		}
 		
+		if(self._ln_ignoringLayoutDuringTransition == NO && self._ln_popupController_nocreate.popupContentView.superview == nil)
+		{
+			//First layout after presentation; add the popup views to the hierarchy before computing frames, so they are set in the correct coordinate space.
+			[self _layoutPopupBarOrderForUse];
+		}
+		
 		if(self._ln_ignoringLayoutDuringTransition == NO && self._ln_popupController_nocreate.popupControllerInternalState != LNPopupPresentationStateBarHidden)
 		{
 			[self._ln_popupController_nocreate _setContentToState:self._ln_popupController_nocreate.popupControllerInternalState animated:NO];


### PR DESCRIPTION
## Problem

`presentPopupBar(with:openPopup:true)` animates the popup content in from the container's **top-left corner** (a zero-size rect growing to full screen) instead of rising from the popup bar.

It happens on every first open after a presentation when the container is a programmatic `UITabBarController`, a `UINavigationController`, a plain `UIViewController`, or a split-view promotion — and on **any** container when re-presenting after `dismissPopupBar`. Storyboard-decoded tab bar controllers only appear immune on their very first presentation. Reproduces on iOS 18.5 and 26.5.

## Cause

The content view's frame is computed before the view is in the hierarchy, and the frame is converted through its (nil) superview:

```objc
// LNPopupController.mm, _repositionPopupContentMovingBottomBar:animated:
if([self.popupContentView isDescendantOfView:controllerForContent.view] == NO)
{
	contentFrame = [self.popupContentView.superview convertRect:contentFrame fromView:controllerForContent.view]; // superview is nil → CGRectZero
}
```

`_ln_layoutPopupBarAndContent` then calls `_setContentToState:` (still detached, still `CGRectZero`) **before** `_layoutPopupBarOrderForUse` inserts the view. Whether the zero frame is corrected before the open animation depends on Core Animation happening to run a second layout pass inside the same `layoutIfNeeded`. When it doesn't, the first real frame is applied inside the `UIViewPropertyAnimator` block, and CA records `CGRectZero → closed → open` as two stacked additive animations — the content unfolds from (0,0).

## Fix

1. **`_ln_layoutPopupBarAndContent`** — on the first layout after presentation (content view has no superview), run `_layoutPopupBarOrderForUse` *before* `_setContentToState:`, so frames are computed in the space they're applied in. The existing later call is unchanged (it also syncs `os26TransitionView.frame` from the updated bar frame); the extra call is two same-index `insertSubview:` no-ops. Its condition is a strict subset of the existing call's, so it never inserts views in a state the current code wouldn't.
2. **`_repositionPopupContentMovingBottomBar:`** — only convert when the content view has a superview; keep the container-space frame otherwise.
3. `DEBUG`-only `os_log` if the content frame is ever computed inside an animation while detached — the exact condition behind this bug. Happy to drop it if you'd rather not carry it.

Both functions are unchanged since 4.5.7; this is unrelated to the 4.5.8 present-path changes (#643).

## Before / after

`popupContentView.layer.presentation().frame` after `presentPopupBar(openPopup:true)`, `UITabBarController()`, iPhone 17 Pro Max, iOS 26.5:

| | before | after |
|---|---|---|
| +16 ms | `(0, 0, 13 × 28)` | `(0, 866, 440 × 8)` |
| +100 ms | `(0, 0, 237 × 514)` | `(0, 437, 440 × 478)` |
| animation keys | `position, bounds.size, position-2, bounds.size-2` | `position, bounds.size` |

## Reproduce

Repro project: **https://github.com/dolzhenko-tony/TestPopup** — a minimal Xcode 26 project pinned to LNPopupController 4.5.8, nothing else in it. (`main` reproduces; branch `fixed-lib` points at this PR's branch and behaves correctly.)

1. Clone, open `TestPopup.xcodeproj`, let SPM resolve, run on an iOS 26 simulator (iPhone 17 Pro Max is what the numbers above came from).
2. Tap **Button** → the red popup content grows out of the top-left corner instead of rising from the bar.
3. In `SceneDelegate.swift`, change `let rootSource: RootSource = .programmatic` to `.storyboard` and run again → correct. Same child view controller, same call; only the way the `UITabBarController` is constructed differs.
4. Optional: `UserDefaults.standard.set(true, forKey: "__LNPopupEnableSlowTransitionsDebug")` slows the transition to 4 s and makes the origin obvious.

The relevant call, in `ViewController.swift`:

```swift
container.popupContentView.allowsContentTransition = false
container.presentPopupBar(with: TestPopupViewController(), openPopup: true)
```


## Tested

This branch vs `271ab2a`, same instrumentation (per-frame presentation frames, `animationKeys`, subview order, safe-area insets, console). Everything except the fixed first-open animation is identical:

- **Containers (iOS 26.5):** tab bar controller (programmatic + storyboard), navigation controller ± toolbar, plain view controller, nav-in-tab with `hidesBottomBarWhenPushed`, split-view promotion, custom `bottomDockingViewForPopupBar`, `shouldExtendPopupBarUnderSafeArea = false`, `inheritsBottomBarMetrics = false`, compact/prominent/floating styles.
- **Flows:** present → open → close → dismiss → re-present, dismiss from open, dismiss/present mid-animation, tab bar hidden before present and shown while open, rotation, suspend/resume, non-animated variants.
- **iOS 18.5:** same tab bar matrix on the non-glass path, including the tab bar slide-down.
- **Visual:** pixel diff of bar-only presentation (glass, shadow, blur), open, close, dismiss, steady states, `allowsContentTransition` on/off — nothing above run-to-run noise.
- **Layout cost:** net fewer layout passes (the `CGRectZero → real frame` churn is gone); `presentPopupBar` measurably cheaper; no re-entrancy, no idle layout activity.

Not exercised: interactive pan gestures (view is attached on that path, so the change doesn't apply), iPad sidebar, Mac Catalyst, iOS ≤ 17.

One note for review: in the iOS 26 fallback where no `*Container*` subview is found, the parent chosen by `_layoutPopupBarOrderForUse` depends on trait-dependent bar margins, and the early call now sees the bar detached. I never observed that branch being taken and the later call re-parents on every pass anyway, so I left it alone rather than add speculative code — flagging it since you know that branch best.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




